### PR TITLE
Add search toggle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,8 @@ Refactoring 2025-05-20:
   </div>
 
   <!-- Suche -->
-  <div id="search-bar" role="search" aria-label="Suche Stakeholder" class="glass-surface">
+  <button id="search-toggle" class="toggle-btn toggle-btn--search" title="Suche ein-/ausblenden" aria-label="Suche ein-/ausblenden">🔍</button>
+  <div id="search-bar" role="search" aria-label="Suche Stakeholder" class="glass-surface is-hidden">
     <input id="search-input" type="text" placeholder="Suche oder Frage stellen..." autocomplete="off">
     <div>
       <button id="search-btn">Suchen</button>

--- a/mindmap.js
+++ b/mindmap.js
@@ -1079,6 +1079,8 @@ window.addEventListener('DOMContentLoaded', () => {
   const importFile = document.getElementById('import-file');
   const clearToggle = document.getElementById('clear-toggle');
   const stickyNodesToggle = document.getElementById('sticky-nodes-toggle');
+  const searchToggle = document.getElementById('search-toggle');
+  const searchBar = document.getElementById('search-bar');
   const resizeHandle = document.getElementById('editor-resizer');
   let isResizing = false;
 
@@ -1324,6 +1326,16 @@ window.addEventListener('DOMContentLoaded', () => {
     document.documentElement.classList.toggle('dark-mode');
     darkToggle.classList.toggle('toggle-btn--active', body.classList.contains('dark-mode'));
   });
+  // --- Search-Button ---
+  searchToggle.addEventListener('click', (e) => {
+    e.stopPropagation();
+    const isOpen = searchBar.classList.toggle('is-hidden') === false;
+    searchToggle.classList.toggle('toggle-btn--active', isOpen);
+    paletteMenu.classList.add('is-hidden');
+    paletteToggle.classList.remove('toggle-btn--active');
+    exportBar.classList.add('is-hidden');
+    exportToggle.classList.remove('toggle-btn--active');
+  });
   // --- Relations-Toggle (optional, falls vorhanden) ---
   const relationsToggle = document.getElementById('relations-toggle');
   if (relationsToggle) {
@@ -1390,6 +1402,10 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     if (!infoMenu.contains(e.target) && e.target !== infoToggle) {
       infoMenu.classList.add('is-hidden');
+    }
+    if (!searchBar.contains(e.target) && e.target !== searchToggle) {
+      searchBar.classList.add('is-hidden');
+      searchToggle.classList.remove('toggle-btn--active');
     }
   });
   // --- Export-Funktionen ---

--- a/style.css
+++ b/style.css
@@ -106,6 +106,11 @@ body.dark-mode, html.dark-mode {
   font-size: 20px;
   box-shadow: var(--glass-shadow);
 }
+.toggle-btn--search {
+  left: 24px;
+  right: auto;
+  top: 18px;
+}
 
 /* --- Toggle Buttons (vertical stack, right side) --- */
 #export-toggle { top: 18px; }


### PR DESCRIPTION
## Summary
- add a search toggle button next to the search bar and hide the bar by default
- position the toggle in the top-left like other buttons
- implement JS handlers to open/close the search bar
- close search bar when clicking outside

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68515a93aea883309db1774df0c1c9e8