### PR TITLE
Search bar toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ Refactoring 2025-05-20:
   </div>
 
   <!-- Suche -->
-  <div id="search-bar" role="search" aria-label="Suche Stakeholder" class="glass-surface">
+  <div id="search-bar" role="search" aria-label="Suche Stakeholder" class="glass-surface is-hidden">
     <input id="search-input" type="text" placeholder="Suche oder Frage stellen..." autocomplete="off">
     <div>
       <button id="search-btn">Suchen</button>
@@ -121,6 +121,8 @@ Refactoring 2025-05-20:
   <!-- Main Content -->
   <svg></svg>
   <div id="info-bar" class="glass-surface"></div>
+
+  <button id="search-toggle" class="toggle-btn toggle-btn--search" title="Suche" aria-label="Suche">🔍</button>
 
   <button id="info-toggle" class="toggle-btn toggle-btn--info" title="Hilfe & Informationen" aria-label="Hilfe & Informationen">i</button>
 </body>

--- a/mindmap.js
+++ b/mindmap.js
@@ -983,6 +983,8 @@ window.addEventListener('DOMContentLoaded', () => {
   const importFile = document.getElementById('import-file');
   const clearToggle = document.getElementById('clear-toggle');
   const stickyNodesToggle = document.getElementById('sticky-nodes-toggle');
+  const searchToggle = document.getElementById('search-toggle');
+  const searchBar = document.getElementById('search-bar');
 
   // --- Export-Button ---
   exportToggle.addEventListener('click', (e) => {
@@ -1221,6 +1223,13 @@ window.addEventListener('DOMContentLoaded', () => {
       }
     }
   });
+  // --- Search-Button ---
+  searchToggle.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const hidden = searchBar.classList.toggle("is-hidden");
+    searchToggle.classList.toggle("toggle-btn--active", !hidden);
+  });
+
   // --- Klick außerhalb schließt Menüs ---
   document.addEventListener('click', (e) => {
     if (!paletteMenu.contains(e.target) && e.target !== paletteToggle) {
@@ -1240,7 +1249,11 @@ window.addEventListener('DOMContentLoaded', () => {
       document.querySelector('svg').style.height = '';
     }
     if (!infoMenu.contains(e.target) && e.target !== infoToggle) {
-      infoMenu.classList.add('is-hidden');
+      infoMenu.classList.add("is-hidden");
+    }
+    if (!searchBar.contains(e.target) && e.target !== searchToggle) {
+      searchBar.classList.add("is-hidden");
+      searchToggle.classList.remove("toggle-btn--active");
     }
   });
   // --- Export-Funktionen ---

--- a/style.css
+++ b/style.css
@@ -96,6 +96,11 @@ body.dark-mode, html.dark-mode {
 .toggle-btn--relations { bottom: 156px; }
 .toggle-btn--palette   { bottom: 248px; }
 .toggle-btn--darkmode  { bottom: 294px; }
+.toggle-btn--search {
+  left: 24px;
+  right: auto;
+  top: 18px;
+}
 .toggle-btn--info {
   left: 24px;
   right: auto;


### PR DESCRIPTION
## Summary
- hide search bar by default and add a search toggle button
- style new search toggle button
- support showing/hiding the search bar via JavaScript

## Testing
- `node --check mindmap.js`

------
https://chatgpt.com/codex/tasks/task_e_685169a812048330abc6ad106ff23b24