### PR TITLE
Fix cluster color palette

### DIFF
--- a/mindmap.js
+++ b/mindmap.js
@@ -911,7 +911,7 @@ function dynamicClusterAdaptation(minConnections = 3) {
   g.selectAll(".cluster-rect").remove();
   g.selectAll(".cluster-label").remove();
 
-  const clusterColors = d3.scaleOrdinal(d3.schemeCategory20); // Neue Farbpalette
+  const clusterColors = d3.scaleOrdinal(d3.schemePaired); // Farbpalette für Cluster
 
   const clusterData = [];
   dynamicClusters.forEach((clusterNodes, clusterId) => {


### PR DESCRIPTION
## Summary
- update `dynamicClusterAdaptation` to use a color scheme available in D3 v7

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852dc0b171c83309fccb9218a128be7