### PR TITLE
Fix search toggle visibility

### DIFF
--- a/mindmap.js
+++ b/mindmap.js
@@ -1844,7 +1844,6 @@ window.addEventListener('DOMContentLoaded', () => {
     const hidden = searchBar.classList.toggle("is-hidden");
     searchToggle.classList.toggle("toggle-btn--active", !hidden);
     searchToggle.classList.toggle("is-hidden", !hidden);
-    searchToggle.classList.toggle("is-hidden", !hidden);
   });
 
 
@@ -1874,7 +1873,6 @@ window.addEventListener('DOMContentLoaded', () => {
       searchToggle.classList.remove("toggle-btn--active");
       searchToggle.classList.remove("is-hidden");
       if (searchResults) searchResults.style.display = "none";
-      searchToggle.classList.remove("is-hidden");
     }
     // NEU: View Style Toggle
     if (!viewStyleMenu.contains(e.target) && e.target !== viewStyleToggle) {


### PR DESCRIPTION
## Summary
- remove duplicate is-hidden toggles when opening/closing search bar
- keep only one toggle to hide the search button

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6852dc08e2508330ad8bb70e9ba5c5a3