### PR TITLE
Fix clusterToggle scope error

### DIFF
--- a/mindmap.js
+++ b/mindmap.js
@@ -1853,7 +1853,6 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   // --- Cluster-Toggle (Gruppierung der Knoten) ---
-  const clusterToggle = document.getElementById('cluster-toggle');
   clusterToggle.addEventListener('click', (e) => {
     e.stopPropagation();
     


### PR DESCRIPTION
## Summary
- remove duplicate `const clusterToggle` declaration in DOMContentLoaded handler

## Testing
- `node --check mindmap.js`

------
https://chatgpt.com/codex/tasks/task_e_6852df86be948330a03ad6f5d2b16eff