### PR TITLE
Fix mobile spacing for toggle buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,6 +151,18 @@ body.dark-mode, html.dark-mode {
     position: static;
     margin: 0;
   }
+  /* Keep auxiliary buttons spaced from the main control bar */
+  #search-toggle {
+    top: 10px;
+    left: 10px;
+    right: auto;
+  }
+  #info-toggle {
+    top: 70px;
+    left: 10px;
+    right: auto;
+    bottom: auto;
+  }
 }
 
 /* Ensure all toggle buttons are visually consistent */


### PR DESCRIPTION
## Summary
- keep search & info buttons away from the controls bar on very small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852ec076e84833093391110545bdcbe