### PR TITLE
Fix color palette for dynamic cluster rectangles

### DIFF
--- a/mindmap.js
+++ b/mindmap.js
@@ -923,7 +923,8 @@ function dynamicClusterAdaptation(minConnections = 3) {
   g.selectAll(".cluster-rect").remove();
   g.selectAll(".cluster-label").remove();
 
-  const clusterColors = d3.scaleOrdinal(d3.schemePaired); // Farbpalette für Cluster
+  // Verwende eine moderne Farbpalette aus d3-scale-chromatic
+  const clusterColors = d3.scaleOrdinal(d3.schemeTableau10); // Farbpalette für Cluster
 
   const clusterData = [];
   dynamicClusters.forEach((clusterNodes, clusterId) => {


### PR DESCRIPTION
## Summary
- use `d3.schemeTableau10` for dynamic cluster coloration

## Testing
- `npm test` *(fails: package.json missing)*
- `node` sample using d3-scale and d3-scale-chromatic

------
https://chatgpt.com/codex/tasks/task_e_6852ebfa09ac8330b626d0f1ba47b89c